### PR TITLE
Fix sgn(T val) when val == 0

### DIFF
--- a/src/something_math.cpp
+++ b/src/something_math.cpp
@@ -157,7 +157,6 @@ Vec2<float> normalize(Vec2<float> a)
 }
 
 template <typename T> T sgn(T val) {
-    return fabsf(val) / val;
     if (val < 0) {
         return -1;
     } else if (val > 0) {


### PR DESCRIPTION
You tried to implement the function as a one-liner but then someone mentioned it would fail when val == 0 so you decided against the one-liner, but forgot to remove it.

Context: https://www.twitch.tv/videos/590165240?t=1h3m