### PR TITLE
Make Makefile BSD-Make compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 WERROR?=-Werror
 PKGS=sdl2
 CFLAGS=-Wall -Wextra $(WERROR) -pedantic -I.
-CXXFLAGS=$(CFLAGS) -std=c++17 -fno-exceptions $(shell pkg-config --cflags $(PKGS))
+CXXFLAGS=$(CFLAGS) -std=c++17 -fno-exceptions `pkg-config --cflags $(PKGS)`
 CXXFLAGS_DEBUG=$(CXXFLAGS) -O0 -fno-builtin -ggdb
 CXXFLAGS_RELEASE=$(CXXFLAGS) -DSOMETHING_RELEASE -O3 -ggdb
-LIBS=$(shell pkg-config --libs $(PKGS)) -lm
+LIBS=`pkg-config --libs $(PKGS) ` -lm
 
 .PHONY: all
 all: something.debug something.release


### PR DESCRIPTION
Issue was that BSD-Make doesn't support the `$(shell ..)` syntax as this
is a GNU extension. Fix is to define the LIBS variable in a way that it
expands to an inline call to pkg-config instead of expansion in the
variable itself.

Tested on FreeBSD 12.1-RELEASE amd64