### PR TITLE
(#179) Add FPS graph and separate debug overlays

### DIFF
--- a/src/something_game.cpp
+++ b/src/something_game.cpp
@@ -367,22 +367,8 @@ void Game::render(SDL_Renderer *renderer)
         }
     }
 
-    const float PADDING = 20.0f;
-    const float SCALE = 5000.0f;
     if (fps_debug) {
-        for (size_t i = 0; i < FPS_BARS_COUNT - 10; ++i) {
-            size_t j = (frame_delays_begin + i) % FPS_BARS_COUNT;
-            fill_rect(
-                renderer,
-                rect(
-                    vec2(SCREEN_WIDTH - PADDING - (float) (FPS_BARS_COUNT - j) * 2,
-                        SCREEN_HEIGHT - PADDING - frame_delays[j] * SCALE),
-                    2.0f,
-                    frame_delays[j] * SCALE),
-                {   (Uint8) (clamp(      (int) (frame_delays[j] * 1000 * 15) - 255, 0, 255)),
-                    (Uint8) (clamp(510 - (int) (frame_delays[j] * 1000 * 15)      , 0, 255)),
-                    0, 255});
-        }
+        render_fps_overlay(renderer);
     }
 
     popup.render(renderer);
@@ -595,6 +581,25 @@ void Game::render_debug_overlay(SDL_Renderer *renderer, size_t fps)
     }
 
     debug_toolbar.render(renderer, debug_font);
+}
+
+void Game::render_fps_overlay(SDL_Renderer *renderer) {
+    const float PADDING = 20.0f;
+    const float SCALE = 5000.0f;
+    const float BAR_WIDTH = 2.0f;
+    for (size_t i = 0; i < FPS_BARS_COUNT; ++i) {
+        size_t j = (frame_delays_begin + i) % FPS_BARS_COUNT;
+        fill_rect(
+            renderer,
+            rect(
+                vec2(SCREEN_WIDTH - PADDING - (float) (FPS_BARS_COUNT - j) * BAR_WIDTH,
+                    SCREEN_HEIGHT - PADDING - frame_delays[j] * SCALE),
+                BAR_WIDTH,
+                frame_delays[j] * SCALE),
+                {   (Uint8) (clamp(      (int) (frame_delays[j] * 1000 * 15) - 255, 0, 255)),
+                    (Uint8) (clamp(510 - (int) (frame_delays[j] * 1000 * 15)      , 0, 255)),
+                    0, (Uint8) clamp((int) i, 0, 255)});
+    }
 }
 
 int Game::count_alive_projectiles(void)

--- a/src/something_game.cpp
+++ b/src/something_game.cpp
@@ -52,6 +52,14 @@ void Game::handle_event(SDL_Event *event)
 
 
 #ifndef SOMETHING_RELEASE
+        case SDLK_F2: {
+            fps_debug = !fps_debug;
+        } break;
+
+        case SDLK_F3: {
+            bfs_debug = !bfs_debug;
+        } break;
+
         case SDLK_F5: {
             command_reload(this, ""_sv);
         } break;
@@ -337,7 +345,7 @@ void Game::render(SDL_Renderer *renderer)
         }
     }
 
-    if (debug && lock) {
+    if (bfs_debug && lock) {
         grid.render_debug_bfs_overlay(
             renderer,
             &camera,
@@ -356,6 +364,24 @@ void Game::render(SDL_Renderer *renderer)
     for (size_t i = 0; i < ITEMS_COUNT; ++i) {
         if (items[i].type != ITEM_NONE) {
             items[i].render(renderer, camera);
+        }
+    }
+
+    const float PADDING = 20.0f;
+    const float SCALE = 5000.0f;
+    if (fps_debug) {
+        for (size_t i = 0; i < FPS_BARS_COUNT - 10; ++i) {
+            size_t j = (frame_delays_begin + i) % FPS_BARS_COUNT;
+            fill_rect(
+                renderer,
+                rect(
+                    vec2(SCREEN_WIDTH - PADDING - (float) (FPS_BARS_COUNT - j) * 2,
+                        SCREEN_HEIGHT - PADDING - frame_delays[j] * SCALE),
+                    2.0f,
+                    frame_delays[j] * SCALE),
+                {   (Uint8) (clamp(      (int) (frame_delays[j] * 1000 * 15) - 255, 0, 255)),
+                    (Uint8) (clamp(510 - (int) (frame_delays[j] * 1000 * 15)      , 0, 255)),
+                    0, 255});
         }
     }
 

--- a/src/something_game.hpp
+++ b/src/something_game.hpp
@@ -65,12 +65,18 @@ const size_t PROJECTILES_COUNT = 69;
 const size_t ITEMS_COUNT = 69;
 const size_t CAMERA_LOCKS_CAPACITY = 200;
 const size_t ROOM_ROW_COUNT = 8;
+const size_t FPS_BARS_COUNT = 256;
 
 struct Game
 {
     bool quit;
     bool debug;
     bool step_debug;
+    bool bfs_debug;
+    bool fps_debug;
+    float frame_delays[FPS_BARS_COUNT];
+    size_t frame_delays_begin;
+
     Vec2f collision_probe;
     Vec2f mouse_position;
     Vec2i original_mouse_position;

--- a/src/something_game.hpp
+++ b/src/something_game.hpp
@@ -120,6 +120,7 @@ struct Game
     void render(SDL_Renderer *renderer);
     void handle_event(SDL_Event *event);
     void render_debug_overlay(SDL_Renderer *renderer, size_t fps);
+    void render_fps_overlay(SDL_Renderer *renderer);
 
     // Entities of the Game
     void reset_entities();

--- a/src/something_main.cpp
+++ b/src/something_main.cpp
@@ -160,6 +160,10 @@ int main(void)
     while (!game.quit) {
         Uint32 curr_ticks = SDL_GetTicks();
         float elapsed_sec = (float) (curr_ticks - prev_ticks) / 1000.0f;
+        if(game.fps_debug) {
+            game.frame_delays[game.frame_delays_begin] = elapsed_sec;
+            game.frame_delays_begin = (game.frame_delays_begin + 1) % FPS_BARS_COUNT;
+        }
 
         frames_of_current_second += 1;
         next_sec += elapsed_sec;


### PR DESCRIPTION
Close #179 
- To see FPS overlay press `F2`.
- To see BFS overlay press `F3`.

This overlays now can be enabled without entering debug mode.
Colors of bars in the overlay change smoothly in range from 60 to 30 FPS. This is an example of full range:

![FPScolors](https://user-images.githubusercontent.com/4366033/92538913-a9e2c680-f248-11ea-9533-5fb01bc6694d.png)