### PR TITLE
document library dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ $ ## Windows
 $ set __MINGW32__=1 && mingw32-make -B
 $ something.debug
 ```
+## Mininum System Requirements / Dependencies
+
+- libsdl2-dev (>= 2.0.5)
+- libpng16-dev
+- g++ (>= 7.5)


### PR DESCRIPTION
I tried to build this on a pretty old system, this just adds documentation for a few minimum requirements that came up during getting that to work.

I'm not certain which exact g++ version is required but upgrading from `5.4.0` to `7.5.0` got rid of all warnings regarding the `aids` library for me:
```
src/./aids.hpp: In function ‘void aids::sprint(aids::String_Buffer*, Types ...)’:
src/./aids.hpp:643:33: error: expected primary-expression before ‘...’ token
         (sprint1(buffer, args), ...);
                                 ^
```

The code mentioned in [this issue](EasyRPG/obs-config#10) mentions that libsdl2-dev should be at least version 2.0.5. I previously had 2.0.4 which lacks the `SDL_PIXELFORMAT_RGBA32` constant.