### PR TITLE
(#237) Fix warning treated as error

### DIFF
--- a/src/something_commands.cpp
+++ b/src/something_commands.cpp
@@ -159,7 +159,7 @@ void command_history(Game *game, String_View)
             game->console.history.entry_sizes[j],
             game->console.history.entries[j]
         };
-        game->console.println(entry);
+        game->console.history.push(entry);
     }
     game->console.println("--------------------");
 }


### PR DESCRIPTION
Trying to compile with g++ (GCC) 10.2.0 gives me the same
error as reported in issue #237.

The problem seems to be that you are trying to `println` entry
directly when you should just push the entry to history.