### PR TITLE
Stop all enemies in debug mode

### DIFF
--- a/src/something_game.cpp
+++ b/src/something_game.cpp
@@ -152,6 +152,13 @@ void Game::handle_event(SDL_Event *event)
 
             case SDLK_q: {
                 debug = !debug;
+                if (debug) {
+                    for (size_t i = ENEMY_ENTITY_INDEX_OFFSET; i < ENTITIES_COUNT; ++i) {
+                        if (entities[i].state == Entity_State::Alive) {
+                            entities[i].stop();
+                        }
+                    }
+                }
             } break;
 
             case SDLK_z: {


### PR DESCRIPTION
![123123](https://user-images.githubusercontent.com/4366033/97804172-bedf4300-1c56-11eb-8ab6-ceaa5b7ae62b.jpg)

If you enter debug mode while enemy is moving towards you, he'll continue to move in that direction forever.