### PR TITLE
Fix MinGW build and refactor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 WERROR?=-Werror
 PKGS=sdl2
 CFLAGS=-Wall -Wextra $(WERROR) -pedantic -I.
+CXXFLAGS_WITHOUT_PKGS=$(CFLAGS) -std=c++17 -fno-exceptions -Wno-missing-braces -Wswitch-enum
 ifdef __MINGW32__
-	CXXFLAGS=$(CFLAGS) -std=c++17 -fno-exceptions -Wno-missing-braces -Wswitch-enum $(shell pkg-config --cflags $(PKGS))
+	CXXFLAGS=$(CXXFLAGS_WITHOUT_PKGS) $(shell pkg-config --cflags $(PKGS))
 	LIBS=$(shell pkg-config --libs $(PKGS)) -lm
 else
-	CXXFLAGS=$(CFLAGS) -std=c++17 -fno-exceptions -Wno-missing-braces -Wswitch-enum `pkg-config --cflags $(PKGS)`
+	CXXFLAGS=$(CXXFLAGS_WITHOUT_PKGS) `pkg-config --cflags $(PKGS)`
 	LIBS=`pkg-config --libs $(PKGS) ` -lm
 endif
 CXXFLAGS_DEBUG=$(CXXFLAGS) -O0 -fno-builtin -ggdb
+CXXFLAGS_WITHOUT_PKGS_DEBUG=$(CXXFLAGS_WITHOUT_PKGS) -O0 -fno-builtin -ggdb
 CXXFLAGS_RELEASE=$(CXXFLAGS) -DSOMETHING_RELEASE -O3 -ggdb
 
 .PHONY: all
@@ -33,10 +35,10 @@ config_types.hpp: config_typer ./assets/vars.conf
 	"./config_typer" ./assets/vars.conf > config_types.hpp
 
 config_typer: src/config_typer.cpp
-	$(CXX) $(CXXFLAGS_DEBUG) -o config_typer src/config_typer.cpp $(LIBS)
+	$(CXX) $(CXXFLAGS_WITHOUT_PKGS_DEBUG) -o config_typer src/config_typer.cpp
 
 assets_types.hpp: assets_typer ./assets/assets.conf
-	./assets_typer ./assets/assets.conf > assets_types.hpp
+	"./assets_typer" ./assets/assets.conf > assets_types.hpp
 
 assets_typer: src/assets_typer.cpp
-	$(CXX) $(CXXFLAGS_DEBUG) -o assets_typer src/assets_typer.cpp $(LIBS)
+	$(CXX) $(CXXFLAGS_WITHOUT_PKGS_DEBUG) -o assets_typer src/assets_typer.cpp

--- a/src/config_typer.cpp
+++ b/src/config_typer.cpp
@@ -7,8 +7,6 @@
 #include <cctype>
 #include <cstring>
 
-#define SDL_MAIN_HANDLED
-#include <SDL.h>
 #include "./aids.hpp"
 
 using namespace aids;

--- a/src/something.cpp
+++ b/src/something.cpp
@@ -42,7 +42,7 @@ typedef SSIZE_T ssize_t;
 #  elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) \
 	|| defined(__DragonFly__)
 #    include "something_fmw_kqueue.cpp"
-#  elif defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__)
+#  elif defined(_MSC_VER)
 #    include "something_fmw_iocp.cpp"
 #  else
 #    include "something_fmw_dummy.cpp"


### PR DESCRIPTION
Currently FMW for Windows compiles only by MSVC so I thought that it's good idea to temporary limit inclusion of `something_fmw_iocp.cpp` file until #271 is solved.
In Makefile `CXX_FLAGS` variable includes cflags for SDL. But `config_typer` and `assets_typer` don't need SDL at all. So for MinGW build you need to include SDL.h every time, or refactor `Makefile`. I did the latter to prevent this problem in future.