### PR TITLE
(#169) Add screen space check to select_popup

### DIFF
--- a/assets/vars.conf
+++ b/assets/vars.conf
@@ -127,7 +127,7 @@ CONSOLE_FONT_SIZE_STEP   : float  = 1.0
 SELECT_POPUP_PAD              : float = 10.0
 SELECT_POPUP_BACKGROUND_COLOR : color = 000000ff
 SELECT_POPUP_FOREGROUND_COLOR : color = ffffffff
-SELECT_POPUP_FONT_SIZE        : float = 6
+SELECT_POPUP_FONT_SIZE        : float = CONSOLE_FONT_SIZE
 
 ## PARTICLES #############################
 

--- a/src/something_commands.hpp
+++ b/src/something_commands.hpp
@@ -25,18 +25,20 @@ struct Command
 };
 
 const Command commands[] = {
-    {"help"_sv,        "Print this help"_sv,                  command_help},
-    {"quit"_sv,        "Quit the game"_sv,                    command_quit},
-    {"reset"_sv,       "Reset the state of the entities"_sv,  command_reset},
-    {"spawn_enemy"_sv, "Spawn an enemy"_sv,                   command_spawn_enemy},
     {"close"_sv,       "Close the console"_sv,                command_close},
-#ifndef SOMETHING_RELEASE
-    {"set"_sv,         "Set the value of a variable"_sv,      command_set},
-    {"reload"_sv,      "Reloads the configuration file"_sv,   command_reload},
-#endif // SOMETHING_RELEASE
-    {"save_room"_sv,   "Save current room as new file"_sv,    command_save_room},
+    {"help"_sv,        "Print this help"_sv,                  command_help},
     {"history"_sv,     "Print the history of the Console"_sv, command_history},
     {"noclip"_sv,      "Turn on/off noclip mode"_sv,          command_noclip},
+    {"quit"_sv,        "Quit the game"_sv,                    command_quit},
+#ifndef SOMETHING_RELEASE
+    {"reload"_sv,      "Reloads the configuration file"_sv,   command_reload},
+#endif // SOMETHING_RELEASE
+    {"reset"_sv,       "Reset the state of the entities"_sv,  command_reset},
+    {"save_room"_sv,   "Save current room as new file"_sv,    command_save_room},
+#ifndef SOMETHING_RELEASE
+    {"set"_sv,         "Set the value of a variable"_sv,      command_set},
+#endif // SOMETHING_RELEASE
+    {"spawn_enemy"_sv, "Spawn an enemy"_sv,                   command_spawn_enemy},
 };
 const size_t commands_count = sizeof(commands) / sizeof(commands[0]);
 

--- a/src/something_console.cpp
+++ b/src/something_console.cpp
@@ -105,10 +105,10 @@ void Console::handle_event(SDL_Event *event, Game *game)
                     completion_popup_enabled = false;
                 } break;
                 case SDLK_UP: {
-                    completion_popup.up();
+                    completion_popup.flipped ? completion_popup.down() : completion_popup.up();
                 } break;
                 case SDLK_DOWN: {
-                    completion_popup.down();
+                    completion_popup.flipped ? completion_popup.up() : completion_popup.down();
                 } break;
                 case SDLK_RETURN: {
                     auto s = completion_popup.items[completion_popup.items_cursor];

--- a/src/something_console.cpp
+++ b/src/something_console.cpp
@@ -81,6 +81,11 @@ void Console::handle_event(SDL_Event *event, Game *game)
                     assert(varindex >= 0);
                     assert(config_types[varindex] == CONFIG_TYPE_FLOAT);
                     config_values[varindex].float_value += CONSOLE_FONT_SIZE_STEP;
+
+                    const auto varindex2 = config_index_by_name("SELECT_POPUP_FONT_SIZE"_sv);
+                    assert(varindex2 >= 0);
+                    assert(config_types[varindex2] == CONFIG_TYPE_FLOAT);
+                    config_values[varindex2].float_value += CONSOLE_FONT_SIZE_STEP;
                 }
             } break;
 
@@ -90,6 +95,11 @@ void Console::handle_event(SDL_Event *event, Game *game)
                     assert(varindex >= 0);
                     assert(config_types[varindex] == CONFIG_TYPE_FLOAT);
                     config_values[varindex].float_value -= CONSOLE_FONT_SIZE_STEP;
+
+                    const auto varindex2 = config_index_by_name("SELECT_POPUP_FONT_SIZE"_sv);
+                    assert(varindex2 >= 0);
+                    assert(config_types[varindex2] == CONFIG_TYPE_FLOAT);
+                    config_values[varindex2].float_value -= CONSOLE_FONT_SIZE_STEP;
                 }
             } break;
             }

--- a/src/something_console.cpp
+++ b/src/something_console.cpp
@@ -75,6 +75,7 @@ void Console::handle_event(SDL_Event *event, Game *game)
         switch (event->type) {
         case SDL_KEYDOWN: {
             switch (event->key.keysym.sym) {
+            case SDLK_KP_PLUS:
             case SDLK_EQUALS: {
                 if (event->key.keysym.mod & KMOD_LCTRL) {
                     const auto varindex = config_index_by_name("CONSOLE_FONT_SIZE"_sv);
@@ -89,6 +90,7 @@ void Console::handle_event(SDL_Event *event, Game *game)
                 }
             } break;
 
+            case SDLK_KP_MINUS:
             case SDLK_MINUS: {
                 if (event->key.keysym.mod & KMOD_LCTRL) {
                     const auto varindex = config_index_by_name("CONSOLE_FONT_SIZE"_sv);
@@ -111,6 +113,7 @@ void Console::handle_event(SDL_Event *event, Game *game)
             switch (event->type) {
             case SDL_KEYDOWN: {
                 switch (event->key.keysym.sym) {
+                case SDLK_BACKSPACE:
                 case SDLK_ESCAPE: {
                     completion_popup_enabled = false;
                 } break;
@@ -120,6 +123,8 @@ void Console::handle_event(SDL_Event *event, Game *game)
                 case SDLK_DOWN: {
                     completion_popup.flipped ? completion_popup.up() : completion_popup.down();
                 } break;
+                case SDLK_SPACE:
+                case SDLK_KP_ENTER:
                 case SDLK_RETURN: {
                     auto s = completion_popup.items[completion_popup.items_cursor];
                     s.chop(edit_field.edit_field_cursor);
@@ -130,7 +135,7 @@ void Console::handle_event(SDL_Event *event, Game *game)
             } break;
             }
         } else {
-            if (event->type == SDL_KEYDOWN && event->key.keysym.sym == SDLK_RETURN) {
+            if (event->type == SDL_KEYDOWN && (event->key.keysym.sym == SDLK_RETURN || event->key.keysym.sym == SDLK_KP_ENTER)) {
                 scroll = 0;
                 String_View command_expr = edit_field.as_string_view().trim();
 

--- a/src/something_select_popup.cpp
+++ b/src/something_select_popup.cpp
@@ -3,6 +3,7 @@
 // TODO(#169): Select_Popup does not handle well out of the screen rendering
 void Select_Popup::render(SDL_Renderer *renderer, Bitmap_Font *font, Vec2f pos)
 {
+    pos.y -= SELECT_POPUP_PAD; // To align baseline of first item in Select_Popup to already typed text in console
     size_t longest_length = 0;
     for (size_t i = 0; i < items_size; ++i) {
         longest_length = max(longest_length, items[i].count);
@@ -12,10 +13,15 @@ void Select_Popup::render(SDL_Renderer *renderer, Bitmap_Font *font, Vec2f pos)
     const float item_height = BITMAP_FONT_CHAR_HEIGHT * SELECT_POPUP_FONT_SIZE + SELECT_POPUP_PAD * 2;
     const float popup_height = items_size * item_height;
 
+    flipped = pos.y + popup_height > SCREEN_HEIGHT;
+    if(flipped) {
+        pos.y -= popup_height - BITMAP_FONT_CHAR_HEIGHT * CONSOLE_FONT_SIZE - SELECT_POPUP_PAD * 2;
+    }
+
     fill_rect(renderer, rect(pos, popup_width, popup_height), SELECT_POPUP_BACKGROUND_COLOR);
 
     for (size_t i = 0; i < items_size; ++i) {
-        const auto item_position = pos + vec2(0.0f, i * item_height);
+        const auto item_position = pos + vec2(0.0f, (flipped ? items_size - 1 - i : i) * item_height);
         const auto text_position = item_position + vec2(SELECT_POPUP_PAD, SELECT_POPUP_PAD);
         if (i == items_cursor) {
             fill_rect(renderer, rect(item_position, popup_width, item_height), SELECT_POPUP_FOREGROUND_COLOR);

--- a/src/something_select_popup.hpp
+++ b/src/something_select_popup.hpp
@@ -8,6 +8,7 @@ struct Select_Popup
     String_View items[SELECT_POPUP_CAPACITY];
     size_t items_size;
     size_t items_cursor;
+    bool flipped;
 
     void render(SDL_Renderer *renderer, Bitmap_Font *font, Vec2f pos);
     void update(float dt);


### PR DESCRIPTION
Close #169 
Autocompletion popup now renders upwards if there's not enough space below the console input.

Other changes:

* Aligned baseline of first item in Select_Popup to already typed text in console.

* Synchronized font size of popup with font size of the console.

* Added support for Numpad keys. And added `Space` as completion approval key. And close it with `Backspace`.

* Sorted console commands in alphabetical order.