### PR TITLE
Rename SEPARATE_FILE_HPP_ -> SOMETHING_PARSERS_HPP_

### DIFF
--- a/src/something_parsers.hpp
+++ b/src/something_parsers.hpp
@@ -1,5 +1,5 @@
-#ifndef SEPARATE_FILE_HPP_
-#define SEPARATE_FILE_HPP_
+#ifndef SOMETHING_PARSERS_HPP_
+#define SOMETHING_PARSERS_HPP_
 
 struct Config_Parse_Result
 {
@@ -51,4 +51,4 @@ Config_Parse_Result parse_vars_conf(String_View input, F f)
 
 // TODO(#290): add animat files parser to something_parsers.hpp
 
-#endif  // SEPARATE_FILE_HPP_
+#endif  // SOMETHING_PARSERS_HPP_


### PR DESCRIPTION
to prevent painful debugging if a new file will also have SEPARETE_FILE_HPP_ guards

---

Such a shame that `decemberfest 2020` isn't a thing...