### PR TITLE
__MINGW32__ and addsuffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@ WERROR?=-Werror
 PKGS=sdl2
 CFLAGS=-Wall -Wextra $(WERROR) -pedantic -I.
 CXXFLAGS_WITHOUT_PKGS=$(CFLAGS) -std=c++17 -fno-exceptions -Wno-missing-braces -Wswitch-enum
-ifdef __MINGW32__
+ifdef OS # https://stackoverflow.com/questions/4058840/makefile-that-distincts-between-windows-and-unix-like-systems	
 	CXXFLAGS=$(CXXFLAGS_WITHOUT_PKGS) $(shell pkg-config --cflags $(PKGS))
 	LIBS=$(shell pkg-config --libs $(PKGS)) -lm
+	EXESUFF=.exe
 else
 	CXXFLAGS=$(CXXFLAGS_WITHOUT_PKGS) `pkg-config --cflags $(PKGS)`
 	LIBS=`pkg-config --libs $(PKGS) ` -lm
+	EXESUFF=
 endif
 CXXFLAGS_DEBUG=$(CXXFLAGS) -O0 -fno-builtin -ggdb
 CXXFLAGS_WITHOUT_PKGS_DEBUG=$(CXXFLAGS_WITHOUT_PKGS) -O0 -fno-builtin -ggdb
@@ -17,10 +19,10 @@ CXXFLAGS_RELEASE=$(CXXFLAGS) -DSOMETHING_RELEASE -O3 -ggdb
 all: something.debug something.release
 
 something.debug: $(wildcard src/something*.cpp) $(wildcard src/something*.hpp) stb_image.o config_types.hpp assets_types.hpp
-	$(CXX) $(CXXFLAGS_DEBUG) -o something.debug src/something.cpp stb_image.o $(LIBS)
+	$(CXX) $(CXXFLAGS_DEBUG) -o $(addsuffix $(EXESUFF),something.debug) src/something.cpp stb_image.o $(LIBS)
 
 something.release: $(wildcard src/something*.cpp) $(wildcard src/something*.hpp) baked_config.hpp assets_types.hpp
-	$(CXX) $(CXXFLAGS_RELEASE) -o something.release src/something.cpp $(LIBS)
+	$(CXX) $(CXXFLAGS_RELEASE) -o $(addsuffix $(EXESUFF),something.release) src/something.cpp $(LIBS)
 
 stb_image.o: src/stb_image.h
 	$(CC) $(CFLAGS) -x c -ggdb -DSTBI_ONLY_PNG -DSTB_IMAGE_IMPLEMENTATION -c -o stb_image.o src/stb_image.h


### PR DESCRIPTION
__MINGW32__ switch not needed. OS automatically defined in windows. addsuffix ".EXE" is for windows apps.

Tested on mingw64_i686 with msys2. 
Tested on debian.