### PR TITLE
Actualizing windows quick_start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ $ ## UNIX-like system
 $ make -B
 $ ./something.debug
 $ ## Windows
-$ set __MINGW32__=1 && mingw32-make -B
-$ something.debug
+$ mingw32-make -B
+$ something.debug.exe
 ```
 ## Mininum System Requirements / Dependencies
 


### PR DESCRIPTION
New makefile works without `__MINGW32__`.
Additional suffix is `.exe` for windows for now.